### PR TITLE
make session id accessable by handler

### DIFF
--- a/lib/SockJS.pm
+++ b/lib/SockJS.pm
@@ -106,7 +106,7 @@ sub _dispatch_transport {
     my $session = $self->{sessions}->{$id};
 
     if (!$session || $transport->name eq 'websocket') {
-        $session = $self->{session_factory}->($self);
+        $session = $self->{session_factory}->($self, $id);
 
         if ($transport->name eq 'websocket') {
             push @{$self->{sessions}->{$id}}, $session;


### PR DESCRIPTION
Though SockJS and all sessions could be accessed by handler with the custom session_factory constructor, current/self session id still has no way to be accessed by handler.
SockJS->new(
        session_factory => sub {
            my $parent = shift;
            weaken $parent;
            SockJS::Session->new( parent => $parent)
        },
);

By having this change, handlers can access current/self session id if they use the custom session_factory constructor below.
SockJS->new(
        session_factory => sub {
            my $parent = shift;
            my $id = shift;
            weaken $parent;
            SockJS::Session->new( parent => $parent, id => $id)
        },
);

Knowing current/self session id is a must-have in many situations, so passing it (or PATH_INFO/REQUEST_URI, or $env even better) to handler in some way might be a good idea, to avoid too much dirty hacks in the codebase.
